### PR TITLE
Updated location specific pricing for hw create-options

### DIFF
--- a/SoftLayer/CLI/hardware/create_options.py
+++ b/SoftLayer/CLI/hardware/create_options.py
@@ -7,18 +7,17 @@ from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
 from SoftLayer.managers import hardware
 
-
 @click.command()
 @click.argument('location', required=False)
-@click.option('--prices', '-p', is_flag=True, help='Use --prices to list the server item prices, and '
-                                                   'to list the Item Prices by location, add it to the '
-                                                   '--prices option using location KeyName, e.g. --prices AMSTERDAM02')
+@click.option('--prices', '-p', is_flag=True,
+              help='Use --prices to list the server item prices, and to list the Item Prices by location,'
+                   'add it to the --prices option using location short name, e.g. --prices dal13')
 @environment.pass_env
 def cli(env, prices, location=None):
     """Server order options for a given chassis."""
 
     hardware_manager = hardware.HardwareManager(env.client)
-    options = hardware_manager.get_create_options()
+    options = hardware_manager.get_create_options(location)
 
     tables = []
 
@@ -35,9 +34,6 @@ def cli(env, prices, location=None):
         _os_prices_table(options['operating_systems'], tables)
         _port_speed_prices_table(options['port_speeds'], tables)
         _extras_prices_table(options['extras'], tables)
-        if location:
-            location_prices = hardware_manager.get_hardware_item_prices(location)
-            _location_item_prices(location_prices, tables)
     else:
         # Presets
         preset_table = formatting.Table(['Size', 'Value'], title="Sizes")


### PR DESCRIPTION
So I wanted location specific pricing to just update on the list, but that turns out to be super complicated. I did get it working I think, but I could use your help getting the code compliant with `tox`, and unit tested. And actual tested, to make sure the math matches what the portal shows.

Some big changes in the hardware manager:

1. _get_package makes several different API calls now, but uses the package id directly, instead of making a bit getAllObjects call
2. `get_item_price` and `_get_preset_cost` changed up to accept locations, and a lot of if statements to get it working right.
3. Added a bit to `get_create_options` to check that the input DC (using shortname now, since that is what create-options shows) is a real datacenter